### PR TITLE
Update notification service url

### DIFF
--- a/app/src/main/java/de/zalando/zmon/util/PreferencesHelper.java
+++ b/app/src/main/java/de/zalando/zmon/util/PreferencesHelper.java
@@ -7,8 +7,8 @@ import android.preference.PreferenceManager;
 public class PreferencesHelper {
 
     private static final String DEFAULT_OAUTH_TOKEN_URL = "https://token.auth.zalando.com";
-    private static final String DEFAULT_DATA_SERVICE_URL = "https://zmon-notification-service.stups.zalan.do";
-    private static final String DEFAULT_NOTIFICATION_SERVICE_URL = "https://zmon-notification-service.stups.zalan.do";
+    private static final String DEFAULT_DATA_SERVICE_URL = "https://notification-service.zmon.zalan.do";
+    private static final String DEFAULT_NOTIFICATION_SERVICE_URL = "https://notification-service.zmon.zalan.do";
     private static final String CONTENT_SETTINGS_SYSTEM_NOTIFICATION_SOUND = "content://settings/system/notification_sound";
 
     private static final String PREF_OAUTH_TOKEN_SERVICE_URL = "zmon_oauth_token_service_url";

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -13,7 +13,7 @@
 
     <EditTextPreference
         android:capitalize="words"
-        android:defaultValue="https://zmon-notification-service.stups.zalan.do"
+        android:defaultValue="https://notification-service.zmon.zalan.do"
         android:inputType="textUri"
         android:key="zmon_data_service_url"
         android:maxLines="1"
@@ -24,7 +24,7 @@
 
     <EditTextPreference
         android:capitalize="words"
-        android:defaultValue="https://zmon-notification-service.stups.zalan.do"
+        android:defaultValue="https://notification-service.zmon.zalan.do"
         android:inputType="textUri"
         android:key="zmon_notification_service_url"
         android:maxLines="1"

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
         classpath 'com.google.gms:google-services:1.5.0-beta2'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Aug 18 19:15:36 CEST 2015
+#Thu Aug 25 23:36:10 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip


### PR DESCRIPTION
The URLs for the ZMON notification service have changed recently. Though the user can configure this in the app settings, it is more convenient when the app points to the right URLs by default.
